### PR TITLE
Allow block with submit

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,8 +347,8 @@ op.submit!
 ```ruby
 class LocalizedPushOp < ::Subroutine::Op
   field :user
-  field :message, type: :string
-  field :data, type: :hash
+  field :message, type: :string, default: ''
+  field :data, type: :hash, default: {}
 
   validates :message, presence: true
   validates :data, presence: true

--- a/README.md
+++ b/README.md
@@ -368,8 +368,8 @@ class LocalizedPushOp < ::Subroutine::Op
 end
 
 LocalizedPushOp.submit!(user: user) do |op| # with localization!
-  op.message = I18n.t('th.pushes.your_order_has_shipped')
-  op.data.merge!(title: I18n.t('th.pushes.item_shipped'))
+  op.message = I18n.t('pushes.your_order_has_shipped')
+  op.data.merge!(title: I18n.t('pushes.item_shipped'))
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -343,6 +343,36 @@ op.submit!
 # if the op succeeds nothing will be raised, otherwise a ::Subroutine::Failure will be raised.
 ```
 
+#### With a block for pre-op customizations
+```ruby
+class LocalizedPushOp < ::Subroutine::Op
+  field :user
+  field :message, type: :string
+  field :data, type: :hash
+
+  validates :message, presence: true
+  validates :data, presence: true
+
+  protected
+
+  def perform
+    PusherThing.push!(message, data)
+    true
+  end
+
+  def observe_submit
+    I18n.with_locale(user.locale) do
+      yield
+    end
+  end
+end
+
+LocalizedPushOp.submit!(user: user) do |op| # with localization!
+  op.message = I18n.t('th.pushes.your_order_has_shipped')
+  op.data.merge!(title: I18n.t('th.pushes.item_shipped'))
+end
+```
+
 ## Built-in Extensions
 
 ### Subroutine::Association

--- a/lib/subroutine/op.rb
+++ b/lib/subroutine/op.rb
@@ -90,16 +90,15 @@ module Subroutine
       end
 
 
-      def submit!(*args)
+      def submit!(*args, &block)
         op = new(*args)
-        op.submit!
-
+        op.submit!(&block)
         op
       end
 
-      def submit(*args)
+      def submit(*args, &block)
         op = new(*args)
-        op.submit
+        op.submit(&block)
         op
       end
 
@@ -179,10 +178,10 @@ module Subroutine
       @outputs[name.to_sym] = value
     end
 
-    def submit!
-
+    def submit!(&block)
       begin
         observe_submission do
+          yield self if block_given?
           validate_and_perform
         end
       rescue Exception => e
@@ -208,8 +207,8 @@ module Subroutine
     end
 
     # the action which should be invoked upon form submission (from the controller)
-    def submit
-      submit!
+    def submit(&block)
+      submit!(&block)
     rescue Exception => e
       if e.respond_to?(:record)
         inherit_errors(e.record) unless e.record == self

--- a/test/subroutine/base_test.rb
+++ b/test/subroutine/base_test.rb
@@ -207,6 +207,17 @@ module Subroutine
       assert_equal "foo@bar.com", u.email_address
     end
 
+    def test_it_accepts_and_executes_block
+      op = ::SignupOp.submit!(:email => 'foo@bar.com', :password => 'password123') do |sop|
+        parts = sop.email.split('@')
+        parts[0] << '+foo'
+        sop.email = parts.join('@')
+      end
+      u = op.created_user
+
+      assert_equal "foo+foo@bar.com", u.email_address
+    end
+
     def test_it_raises_an_error_if_an_output_is_not_defined_but_is_set
       op = ::MissingOutputOp.new
       assert_raises ::Subroutine::UnknownOutputError do

--- a/test/subroutine/base_test.rb
+++ b/test/subroutine/base_test.rb
@@ -218,6 +218,16 @@ module Subroutine
       assert_equal "foo+foo@bar.com", u.email_address
     end
 
+    def test_it_passes_validation_with_attributes_set_in_block
+      op = ::SignupOp.submit! do |sop|
+        sop.email = 'foo@bar.com'
+        sop.password = 'password123'
+      end
+      u = op.created_user
+
+      assert_equal "foo@bar.com", u.email_address
+    end
+
     def test_it_raises_an_error_if_an_output_is_not_defined_but_is_set
       op = ::MissingOutputOp.new
       assert_raises ::Subroutine::UnknownOutputError do


### PR DESCRIPTION
The section added to the readme explains:

#### With a block for pre-op customizations
```ruby
class LocalizedPushOp < ::Subroutine::Op
  field :user
  field :message, type: :string, default: ''
  field :data, type: :hash, default: {}

  validates :message, presence: true
  validates :data, presence: true

  protected

  def perform
    PusherThing.push!(message, data)
    true
  end

  def observe_submit
    I18n.with_locale(user.locale) do
      yield
    end
  end
end

LocalizedPushOp.submit!(user: user) do |op| # with localization!
  op.message = I18n.t('pushes.your_order_has_shipped')
  op.data.merge!(title: I18n.t('pushes.item_shipped'))
end
```