### PR TITLE
Use alias method chaining instead of overriding initialize in association module

### DIFF
--- a/lib/subroutine/association.rb
+++ b/lib/subroutine/association.rb
@@ -9,8 +9,8 @@ module Subroutine
         alias_method :field, :field_with_associations
       end
 
-      base.alias_method :setup_fields_without_association, :setup_fields
-      base.alias_method :setup_fields, :setup_fields_with_association
+      base.send(:alias_method, :setup_fields_without_association, :setup_fields)
+      base.send(:alias_method, :setup_fields, :setup_fields_with_association)
     end
 
     module ClassMethods

--- a/lib/subroutine/association.rb
+++ b/lib/subroutine/association.rb
@@ -8,6 +8,9 @@ module Subroutine
         alias_method :field_without_associations, :field
         alias_method :field, :field_with_associations
       end
+
+      base.alias_method :setup_fields_without_association, :setup_fields
+      base.alias_method :setup_fields, :setup_fields_with_association
     end
 
     module ClassMethods
@@ -99,8 +102,8 @@ module Subroutine
       end
     end
 
-    def initialize(*args)
-      super(*args)
+    def setup_fields_with_association(*args)
+      setup_fields_without_association(*args)
 
       _fields.each_pair do |field, config|
         next unless config[:association]


### PR DESCRIPTION
Avoid having to super in non-op classes now that the fields module was extracted.

Currently, forgetting to call `super` will result in the foreign_key_method for the association to be null