### PR TITLE
Sanitization Errors

### DIFF
--- a/lib/subroutine/fields.rb
+++ b/lib/subroutine/fields.rb
@@ -115,7 +115,11 @@ module Subroutine
       _fields.each_pair do |field, config|
         next unless inputs.key?(field)
 
-        out[field] = ::Subroutine::TypeCaster.cast(inputs[field], config)
+        begin
+          out[field] = ::Subroutine::TypeCaster.cast(inputs[field], config)
+        rescue ::Subroutine::TypeCaster::TypeCastError => e
+          raise ::Subroutine::TypeCaster::TypeCastError, "Error for field `#{field}`: #{e}"
+        end
       end
 
       out

--- a/lib/subroutine/type_caster.rb
+++ b/lib/subroutine/type_caster.rb
@@ -10,6 +10,15 @@ require 'active_support/core_ext/array/wrap'
 
 module Subroutine
   module TypeCaster
+
+    class TypeCastError < StandardError
+
+      def initialize(message)
+        super(message)
+      end
+
+    end
+
     def self.casters
       @casters ||= {}
     end
@@ -28,6 +37,9 @@ module Subroutine
       return value unless caster
 
       caster.call(value, options)
+
+    rescue StandardError => e
+      raise ::Subroutine::TypeCaster::TypeCastError, e.to_s, e.backtrace
     end
   end
 end

--- a/lib/subroutine/version.rb
+++ b/lib/subroutine/version.rb
@@ -2,8 +2,8 @@
 
 module Subroutine
   MAJOR = 0
-  MINOR = 8
-  PATCH = 2
+  MINOR = 9
+  PATCH = 0
   PRE   = nil
 
   VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join('.')

--- a/test/subroutine/fields_test.rb
+++ b/test/subroutine/fields_test.rb
@@ -12,6 +12,7 @@ module Subroutine
 
       string :foo, default: "foo"
       integer :bar, default: -> { 3 }
+      date :baz
 
       def initialize(options = {})
         setup_fields(options)
@@ -20,9 +21,10 @@ module Subroutine
     end
 
     def test_fields_are_configured
-      assert_equal 2, Whatever._fields.size
+      assert_equal 3, Whatever._fields.size
       assert_equal :string, Whatever._fields[:foo][:type]
       assert_equal :integer, Whatever._fields[:bar][:type]
+      assert_equal :date, Whatever._fields[:baz][:type]
     end
 
     def test_field_defaults_are_handled
@@ -41,6 +43,25 @@ module Subroutine
       instance = Whatever.new(foo: "abc")
       assert_equal true, instance.field_provided?(:foo)
       assert_equal false, instance.field_provided?(:bar)
+    end
+
+    def test_field_provided
+
+      instance = Whatever.new(foo: "abc")
+      assert_equal true, instance.field_provided?(:foo)
+      assert_equal false, instance.field_provided?(:bar)
+
+      instance = DefaultsOp.new
+      assert_equal false, instance.field_provided?(:foo)
+
+      instance = DefaultsOp.new(foo: 'foo')
+      assert_equal true, instance.field_provided?(:foo)
+    end
+
+    def test_invalid_typecast
+      assert_raises "Error for field `baz`: invalid date" do
+        Whatever.new(baz: "2015-13-01")
+      end
     end
 
     def test_params

--- a/test/subroutine/type_caster_test.rb
+++ b/test/subroutine/type_caster_test.rb
@@ -252,18 +252,14 @@ module Subroutine
       op.file_input.unlink
     end
 
-    def test_field_provided
-      op = ::SignupOp.new
-      assert_equal false, op.send(:field_provided?, :email)
+    def test_when_a_type_cast_fails_a_type_cast_error_is_raised
+      assert_raises Subroutine::TypeCaster::TypeCastError do
+        op.date_input = "2015-13-01"
+      end
 
-      op = ::SignupOp.new(email: 'foo')
-      assert_equal true, op.send(:field_provided?, :email)
-
-      op = ::DefaultsOp.new
-      assert_equal false, op.send(:field_provided?, :foo)
-
-      op = ::DefaultsOp.new(foo: 'foo')
-      assert_equal true, op.send(:field_provided?, :foo)
+      assert_raises "invalid date" do
+        op.date_input = "2015-13-01"
+      end
     end
   end
 end


### PR DESCRIPTION
Raise a specific type of error when a sanitizer is unable to process input. In the context of the fields mixin, raise a similar error but with information about which field it came from.