### PR TITLE
Failure class configuration

### DIFF
--- a/lib/subroutine/op.rb
+++ b/lib/subroutine/op.rb
@@ -21,6 +21,10 @@ module Subroutine
 
     class << self
 
+      def failure_class(klass)
+        self._failure_class = klass
+      end
+
       def outputs(*names)
         options = names.extract_options!
         names.each do |name|
@@ -76,6 +80,9 @@ module Subroutine
 
     end
 
+    class_attribute :_failure_class
+    self._failure_class = Subroutine::Failure
+
     class_attribute :_outputs
     self._outputs = {}
 
@@ -110,7 +117,7 @@ module Subroutine
       rescue Exception => e
         if e.respond_to?(:record)
           inherit_errors(e.record) unless e.record == self
-          new_e = ::Subroutine::Failure.new(self)
+          new_e = _failure_class.new(self)
           raise new_e, new_e.message, e.backtrace
         else
           raise
@@ -126,7 +133,7 @@ module Subroutine
 
         true
       else
-        raise ::Subroutine::Failure, self
+        raise _failure_class, self
       end
     end
 

--- a/test/subroutine/base_test.rb
+++ b/test/subroutine/base_test.rb
@@ -135,15 +135,13 @@ module Subroutine
     end
 
     def test_uses_failure_class_to_raise_error
-      ::SignupOp.failure_class(::SignupOp::Failure)
+      op = ::CustomFailureClassOp.new
 
-      op = ::SignupOp.new(email: 'foo@bar.com')
-
-      err = assert_raises ::SignupOp::Failure do
+      err = assert_raises ::CustomFailureClassOp::Failure do
         op.submit!
       end
 
-      assert_equal "Password can't be blank", err.message
+      assert_equal "Will never work", err.message
     end
 
     def test_the_result_of_perform_doesnt_matter

--- a/test/subroutine/base_test.rb
+++ b/test/subroutine/base_test.rb
@@ -134,6 +134,18 @@ module Subroutine
       assert_equal "Password can't be blank", err.message
     end
 
+    def test_uses_failure_class_to_raise_error
+      ::SignupOp.failure_class(::SignupOp::Failure)
+
+      op = ::SignupOp.new(email: 'foo@bar.com')
+
+      err = assert_raises ::SignupOp::Failure do
+        op.submit!
+      end
+
+      assert_equal "Password can't be blank", err.message
+    end
+
     def test_the_result_of_perform_doesnt_matter
       op = ::FalsePerformOp.new
       assert op.submit!

--- a/test/support/ops.rb
+++ b/test/support/ops.rb
@@ -26,18 +26,6 @@ end
 ## Ops ##
 
 class SignupOp < ::Subroutine::Op
-  # Normally we'd just inherit from Subroutine::Failure,
-  # but for testing sake let's avoid sharing the hierarchy.
-  class Failure < StandardError
-    attr_reader :record
-    def initialize(record)
-      @record = record
-      errors = @record.errors.full_messages.join(', ')
-      super(errors)
-    end
-  end
-
-
   string :email, aka: :email_address
   string :password
 
@@ -306,5 +294,24 @@ class ErrorTraceOp < ::Subroutine::Op
 
   def perform
     SubOp.submit!
+  end
+end
+
+class CustomFailureClassOp < ::Subroutine::Op
+    # Normally we'd just inherit from Subroutine::Failure,
+  # but for testing sake let's avoid sharing the hierarchy.
+  class Failure < StandardError
+    attr_reader :record
+    def initialize(record)
+      @record = record
+      errors = @record.errors.full_messages.join(', ')
+      super(errors)
+    end
+  end
+
+  failure_class Failure
+
+  def perform
+    errors.add(:base, "Will never work")
   end
 end

--- a/test/support/ops.rb
+++ b/test/support/ops.rb
@@ -26,6 +26,18 @@ end
 ## Ops ##
 
 class SignupOp < ::Subroutine::Op
+  # Normally we'd just inherit from Subroutine::Failure,
+  # but for testing sake let's avoid sharing the hierarchy.
+  class Failure < StandardError
+    attr_reader :record
+    def initialize(record)
+      @record = record
+      errors = @record.errors.full_messages.join(', ')
+      super(errors)
+    end
+  end
+
+
   string :email, aka: :email_address
   string :password
 

--- a/test/support/ops.rb
+++ b/test/support/ops.rb
@@ -298,8 +298,6 @@ class ErrorTraceOp < ::Subroutine::Op
 end
 
 class CustomFailureClassOp < ::Subroutine::Op
-    # Normally we'd just inherit from Subroutine::Failure,
-  # but for testing sake let's avoid sharing the hierarchy.
   class Failure < StandardError
     attr_reader :record
     def initialize(record)


### PR DESCRIPTION
Allow ops to specify the class used for rescuing failures in submit!. By
default this is Subroutine::Failure.

Example:

```ruby
class FooOp < ::Subroutine::Op
  class Failure < ::Subroutine::Failure
  end

  failure_class Failure

  def perform
    Post.find!(-1)
  end

end

# Now raises FooOp::Failure
FooOp.submit!
```