### PR TITLE
Improved foreign_key support

### DIFF
--- a/lib/subroutine/association_fields/configuration.rb
+++ b/lib/subroutine/association_fields/configuration.rb
@@ -10,7 +10,7 @@ module Subroutine
       def validate!
         super
 
-        if as && foreign_key
+        if config[:as] && foreign_key
           raise ArgumentError, ":as and :foreign_key options should not be provided together to an association invocation"
         end
       end

--- a/lib/subroutine/association_fields/configuration.rb
+++ b/lib/subroutine/association_fields/configuration.rb
@@ -55,7 +55,7 @@ module Subroutine
       end
 
       def build_foreign_key_field
-        build_child_field(foreign_key_method, type: :integer)
+        build_child_field(foreign_key_method)
       end
 
       def build_foreign_type_field

--- a/test/subroutine/association_test.rb
+++ b/test/subroutine/association_test.rb
@@ -70,6 +70,12 @@ module Subroutine
       assert_equal "AdminUser", op.admin_type
     end
 
+    def test_it_allows_foreign_keys_to_be_set
+      op = ::AssociationWithForeignKeyOp.new(admin: doug)
+      assert_equal doug.id, op.user_id
+      assert_equal "user_id", op.field_configurations[:admin][:foreign_key]
+    end
+
     def test_it_inherits_associations_via_fields_from
       all_mock = mock
 

--- a/test/subroutine/association_test.rb
+++ b/test/subroutine/association_test.rb
@@ -27,7 +27,7 @@ module Subroutine
       all_mock = mock
 
       ::User.expects(:all).returns(all_mock)
-      all_mock.expects(:find).with(1).returns(doug)
+      all_mock.expects(:find_by!).with(id: 1).returns(doug)
 
       op = SimpleAssociationOp.new user_type: "User", user_id: doug.id
       assert_equal doug, op.user
@@ -37,7 +37,7 @@ module Subroutine
       all_mock = mock
 
       ::User.expects(:all).returns(all_mock)
-      all_mock.expects(:find).with(1).returns(doug)
+      all_mock.expects(:find_by!).with(id: 1).returns(doug)
 
       op = SimpleAssociationOp.new user_id: doug.id
       assert_equal doug, op.user
@@ -49,7 +49,7 @@ module Subroutine
 
       ::User.expects(:all).returns(all_mock)
       all_mock.expects(:unscoped).returns(unscoped_mock)
-      unscoped_mock.expects(:find).with(1).returns(doug)
+      unscoped_mock.expects(:find_by!).with(id: 1).returns(doug)
 
       op = UnscopedSimpleAssociationOp.new user_id: doug.id
       assert_equal doug, op.user
@@ -59,7 +59,7 @@ module Subroutine
       all_mock = mock
       ::User.expects(:all).never
       ::AdminUser.expects(:all).returns(all_mock)
-      all_mock.expects(:find).with(1).returns(doug)
+      all_mock.expects(:find_by!).with(id: 1).returns(doug)
 
       op = PolymorphicAssociationOp.new(admin_type: "AdminUser", admin_id: doug.id)
       assert_equal doug, op.admin
@@ -71,16 +71,20 @@ module Subroutine
     end
 
     def test_it_allows_foreign_keys_to_be_set
-      op = ::AssociationWithForeignKeyOp.new(admin: doug)
-      assert_equal doug.id, op.user_id
-      assert_equal "user_id", op.field_configurations[:admin][:foreign_key]
+      all_mock = mock
+      ::User.expects(:all).returns(all_mock)
+      all_mock.expects(:find_by!).with("email_address" => doug.email_address).returns(doug)
+
+      op = ::AssociationWithForeignKeyOp.new(email_address: doug.email_address)
+      assert_equal doug, op.user
+      assert_equal "email_address", op.field_configurations[:user][:foreign_key]
     end
 
     def test_it_inherits_associations_via_fields_from
       all_mock = mock
 
       ::User.expects(:all).returns(all_mock)
-      all_mock.expects(:find).with(1).returns(doug)
+      all_mock.expects(:find_by!).with(id: 1).returns(doug)
 
       op = ::InheritedSimpleAssociation.new(user_type: "User", user_id: doug.id)
       assert_equal doug, op.user
@@ -94,7 +98,7 @@ module Subroutine
 
       ::User.expects(:all).returns(all_mock)
       all_mock.expects(:unscoped).returns(unscoped_mock)
-      unscoped_mock.expects(:find).with(1).returns(doug)
+      unscoped_mock.expects(:find_by!).with(id: 1).returns(doug)
 
       op = ::InheritedUnscopedAssociation.new(user_type: "User", user_id: doug.id)
       assert_equal doug, op.user
@@ -106,7 +110,7 @@ module Subroutine
       all_mock = mock
       ::User.expects(:all).never
       ::AdminUser.expects(:all).returns(all_mock)
-      all_mock.expects(:find).with(1).returns(doug)
+      all_mock.expects(:find_by!).with(id: 1).returns(doug)
 
       op = ::InheritedPolymorphicAssociationOp.new(admin_type: "AdminUser", admin_id: doug.id)
       assert_equal doug, op.admin

--- a/test/support/ops.rb
+++ b/test/support/ops.rb
@@ -304,6 +304,12 @@ class AssociationWithClassOp < ::OpWithAssociation
 
 end
 
+class AssociationWithForeignKeyOp < ::OpWithAssociation
+
+  association :admin, class_name: "AdminUser", foreign_key: "user_id"
+
+end
+
 class ExceptAssociationOp < ::Subroutine::Op
 
   fields_from ::PolymorphicAssociationOp, except: %i[admin]

--- a/test/support/ops.rb
+++ b/test/support/ops.rb
@@ -23,6 +23,14 @@ class User
     new(id: id)
   end
 
+  def self.find_by(params)
+    new(params)
+  end
+
+  def self.find_by!(params)
+    find_by(params) || raise
+  end
+
 end
 
 class AdminUser < ::User
@@ -306,7 +314,7 @@ end
 
 class AssociationWithForeignKeyOp < ::OpWithAssociation
 
-  association :admin, class_name: "AdminUser", foreign_key: "user_id"
+  association :user, foreign_key: "email_address"
 
 end
 


### PR DESCRIPTION
On latest master, setting a `foreign_key` on any association in an op results in an error when the op is first loaded. This PR fixes the configuration bug that causes this issue, allowing ops to name associations independently of their key fields. It also improves association instance fetching to allow any type of foreign key.