### PR TITLE
Allow inherit_errors to receive a prefix option

### DIFF
--- a/lib/subroutine/fields/configuration.rb
+++ b/lib/subroutine/fields/configuration.rb
@@ -7,7 +7,7 @@ module Subroutine
     class Configuration < ::SimpleDelegator
 
       PROTECTED_GROUP_IDENTIFIERS = %i[all original default].freeze
-      INHERITABLE_OPTIONS = %i[mass_assignable field_reader field_writer groups].freeze
+      INHERITABLE_OPTIONS = %i[mass_assignable field_reader field_writer groups aka].freeze
       NO_GROUPS = [].freeze
 
       def self.from(field_name, options)
@@ -100,6 +100,7 @@ module Subroutine
         groups = nil if groups == false
         opts[:groups] = Array(groups).map(&:to_sym).presence
         opts.delete(:group)
+        opts[:aka] = opts[:aka].to_sym if opts[:aka]
         opts
       end
 

--- a/lib/subroutine/op.rb
+++ b/lib/subroutine/op.rb
@@ -37,27 +37,10 @@ module Subroutine
         op
       end
 
-      protected
-
-      def field(field_name, options = {})
-        result = super(field_name, options)
-
-        if options[:aka]
-          Array(options[:aka]).each do |as|
-            self._error_map = _error_map.merge(as.to_sym => field_name.to_sym)
-          end
-        end
-
-        result
-      end
-
     end
 
     class_attribute :_failure_class
     self._failure_class = Subroutine::Failure
-
-    class_attribute :_error_map
-    self._error_map = {}
 
     def initialize(inputs = {})
       setup_fields(inputs)
@@ -127,18 +110,23 @@ module Subroutine
       raise NotImplementedError
     end
 
-    # applies the errors in error_object to self
-    # returns false so failure cases can end with this invocation
-    def inherit_errors(error_object)
+    def inherit_errors(error_object, prefix: nil)
       error_object = error_object.errors if error_object.respond_to?(:errors)
 
-      error_object.each do |k, v|
-        if respond_to?(k)
-          errors.add(k, v)
-        elsif _error_map[k.to_sym]
-          errors.add(_error_map[k.to_sym], v)
+      error_object.each do |field_name, error|
+        field_name = "#{prefix}#{field_name}" if prefix
+        field_name = field_name.to_sym
+
+        field_config = get_field_config(field_name)
+        field_config ||= begin
+          kv = field_configurations.find { |_k, config| config[:aka] == field_name }
+          kv ? kv.last : nil
+        end
+
+        if field_config
+          errors.add(field_config.field_name, error)
         else
-          errors.add(:base, error_object.full_message(k, v))
+          errors.add(:base, error_object.full_message(field_name, error))
         end
       end
 

--- a/test/subroutine/base_test.rb
+++ b/test/subroutine/base_test.rb
@@ -127,6 +127,13 @@ module Subroutine
       assert_equal ["has gotta be @admin.com"], op.errors[:email]
     end
 
+    def test_validation_errors_can_be_inherited_and_prefixed
+      op = PrefixedInputsOp.new(user_email_address: "foo@bar.com")
+      refute op.submit
+
+      assert_equal ["has gotta be @admin.com"], op.errors[:user_email_address]
+    end
+
     def test_when_valid_perform_completes_it_returns_control
       op = ::SignupOp.new(email: "foo@bar.com", password: "password123")
       op.submit!

--- a/test/support/ops.rb
+++ b/test/support/ops.rb
@@ -447,3 +447,15 @@ class CustomFailureClassOp < ::Subroutine::Op
   end
 
 end
+
+class PrefixedInputsOp < ::Subroutine::Op
+
+  string :user_email_address
+
+  def perform
+    u = AdminUser.new(email_address: user_email_address)
+    u.valid?
+    inherit_errors(u, prefix: :user_)
+  end
+
+end


### PR DESCRIPTION
This PR allows errors inherited from other objects to apply to prefixed inputs. A nice contrived example to show it off:

```ruby
class User
   validates :email, format: /.+@.+/
end

class Business
  validates :name, length: 3..50
end

class SignupOp
  string :business_name
  string :user_email

  def perform
    create_user
    create_business
  end

  def create_user
    u = User.new(email: user_email)
    u.save and return if u.valid?
    inherit_errors(u, prefix: "user_")
  end

  def create_business
    b = Business.new(name: business_name)
    b.save and return if b.valid?
    inherit_errors(b, prefix: "business_")
  end
end
```