### PR TITLE
Add type validation for Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ class SignupOp < ::Subroutine::Op
   validates :company_name, presence: true
 
   outputs :user
-  outputs :business
+  outputs :business, type: Business # validate that output type is an instance of Business
 
   protected
 

--- a/lib/subroutine/outputs/invalid_output_type_error.rb
+++ b/lib/subroutine/outputs/invalid_output_type_error.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Subroutine
+  module Outputs
+    class InvalidOutputTypeError < StandardError
+
+      def initialize(name:, expected_type:, actual_type:)
+        super("Invalid output type for '#{name}' expected #{expected_type} but got #{actual_type}")
+      end
+
+    end
+  end
+end

--- a/test/subroutine/base_test.rb
+++ b/test/subroutine/base_test.rb
@@ -264,30 +264,6 @@ module Subroutine
       assert_equal Hash, value.class
     end
 
-    def test_it_raises_an_error_if_an_output_is_not_defined_but_is_set
-      op = ::MissingOutputOp.new
-      assert_raises ::Subroutine::Outputs::UnknownOutputError do
-        op.submit
-      end
-    end
-
-    def test_it_raises_an_error_if_not_all_outputs_were_set
-      op = ::MissingOutputSetOp.new
-      assert_raises ::Subroutine::Outputs::OutputNotSetError do
-        op.submit
-      end
-    end
-
-    def test_it_does_not_raise_an_error_if_output_is_not_set_and_is_not_required
-      op = ::OutputNotRequiredOp.new
-      op.submit
-    end
-
-    def test_it_does_not_raise_an_error_if_the_perform_is_not_a_success
-      op = ::NoOutputNoSuccessOp.new
-      refute op.submit
-    end
-
     def test_it_does_not_omit_the_backtrace_from_the_original_error
       op = ::ErrorTraceOp.new
       begin

--- a/test/subroutine/outputs_test.rb
+++ b/test/subroutine/outputs_test.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Subroutine
+  class OutputsTest < TestCase
+    class MissingOutputOp < ::Subroutine::Op
+      def perform
+        output :foo, 'bar'
+      end
+    end
+
+    class MissingOutputSetOp < ::Subroutine::Op
+      outputs :foo
+      def perform
+        true
+      end
+    end
+
+    class OutputNotRequiredOp < ::Subroutine::Op
+      outputs :foo, required: false
+      def perform
+        true
+      end
+    end
+
+    class NoOutputNoSuccessOp < ::Subroutine::Op
+      outputs :foo
+
+      def perform
+        errors.add(:foo, 'bar')
+      end
+    end
+
+    class OutputWithTypeValidationNotRequired < ::Subroutine::Op
+      outputs :value, type: String, required: false
+
+      def perform; end
+    end
+
+    class OutputWithTypeValidationRequired < ::Subroutine::Op
+      outputs :value, type: String, required: true
+
+      def perform; end
+    end
+
+    def test_it_raises_an_error_if_an_output_is_not_defined_but_is_set
+      op = MissingOutputOp.new
+      assert_raises ::Subroutine::Outputs::UnknownOutputError do
+        op.submit
+      end
+    end
+
+    def test_it_raises_an_error_if_not_all_outputs_were_set
+      op = MissingOutputSetOp.new
+      assert_raises ::Subroutine::Outputs::OutputNotSetError do
+        op.submit
+      end
+    end
+
+    def test_it_does_not_raise_an_error_if_output_is_not_set_and_is_not_required
+      op = OutputNotRequiredOp.new
+      op.submit
+    end
+
+    def test_it_does_not_raise_an_error_if_the_perform_is_not_a_success
+      op = NoOutputNoSuccessOp.new
+      refute op.submit
+    end
+
+    ###################
+    # type validation #
+    ###################
+
+    def test_it_does_not_raise_an_error_if_output_is_set_to_the_right_type
+      op = OutputWithTypeValidationNotRequired.new
+      op.send(:output, :value, 'foo')
+      assert op.submit
+    end
+
+    def test_it_raises_an_error_if_output_is_not_set_to_the_right_type
+      op = OutputWithTypeValidationNotRequired.new
+      op.send(:output, :value, 1)
+      assert_raises ::Subroutine::Outputs::InvalidOutputTypeError do
+        op.submit
+      end
+    end
+
+    def test_it_does_not_raise_an_error_if_output_is_set_to_nil_when_there_is_type_validation_and_not_required
+      op = OutputWithTypeValidationNotRequired.new
+      op.send(:output, :value, nil)
+      op.submit
+    end
+
+    def test_it_raises_an_error_if_output_is_set_to_nil_when_there_is_type_validation_and_is_required
+      op = OutputWithTypeValidationRequired.new
+      op.send(:output, :value, nil)
+      assert_raises ::Subroutine::Outputs::InvalidOutputTypeError do
+        op.submit
+      end
+    end
+  end
+end

--- a/test/support/ops.rb
+++ b/test/support/ops.rb
@@ -417,41 +417,6 @@ class FalsePerformOp < ::Subroutine::Op
 
 end
 
-class MissingOutputOp < ::Subroutine::Op
-
-  def perform
-    output :foo, "bar"
-  end
-
-end
-
-class MissingOutputSetOp < ::Subroutine::Op
-
-  outputs :foo
-  def perform
-    true
-  end
-
-end
-
-class OutputNotRequiredOp < ::Subroutine::Op
-
-  outputs :foo, required: false
-  def perform
-    true
-  end
-
-end
-
-class NoOutputNoSuccessOp < ::Subroutine::Op
-
-  outputs :foo
-  def perform
-    errors.add(:foo, "bar")
-  end
-
-end
-
 class ErrorTraceOp < ::Subroutine::Op
 
   class SomeObject


### PR DESCRIPTION
Usage
```
class OutputWithTypeValidationNotRequired < ::Subroutine::Op
  outputs :value, type: String, required: false

  def perform; end
end

class OutputWithTypeValidationRequired < ::Subroutine::Op
  outputs :value, type: Boolean

  def perform; end
end
```

Additional changes:

updated `output_provided?(name)` to only return a boolean, I removed the `raise ::Subroutine::Outputs::UnknownOutputError` from the method.
`validate_output!` is the only caller of `output_provided?` and its only calling it from the configuration ( which means that they are defined )

`Subroutine::Outputs::UnknownOutputError` is still raised when using `output` and `get_output` with output is unknown
