### PR TITLE
Fix for eager loading

### DIFF
--- a/lib/subroutine/association_fields/configuration.rb
+++ b/lib/subroutine/association_fields/configuration.rb
@@ -60,7 +60,7 @@ module Subroutine
       end
 
       def build_foreign_key_field
-        build_child_field(foreign_key_method, type: :foreign_key, foreign_key_type: determine_foreign_key_type)
+        build_child_field(foreign_key_method, type: :foreign_key, foreign_key_type: -> { determine_foreign_key_type })
       end
 
       def build_foreign_type_field
@@ -92,8 +92,6 @@ module Subroutine
 
         klass = inferred_foreign_type&.constantize
         if klass && klass.respond_to?(:type_for_attribute)
-          return unless klass.table_exists?
-          
           case klass.type_for_attribute(find_by)&.type&.to_sym
           when :string
             :string

--- a/lib/subroutine/association_fields/configuration.rb
+++ b/lib/subroutine/association_fields/configuration.rb
@@ -92,6 +92,8 @@ module Subroutine
 
         klass = inferred_foreign_type&.constantize
         if klass && klass.respond_to?(:type_for_attribute)
+          return unless klass.table_exists?
+          
           case klass.type_for_attribute(find_by)&.type&.to_sym
           when :string
             :string

--- a/lib/subroutine/association_fields/configuration.rb
+++ b/lib/subroutine/association_fields/configuration.rb
@@ -90,15 +90,17 @@ module Subroutine
         # TODO: Make this logic work for polymorphic associations.
         return if polymorphic?
 
-        klass = inferred_foreign_type&.constantize
-        if klass && klass.respond_to?(:type_for_attribute)
-          case klass.type_for_attribute(find_by)&.type&.to_sym
-          when :string
-            :string
-          else
-            :integer
+        @determined_foreign_type ||= begin
+          klass = inferred_foreign_type&.constantize
+          if klass && klass.respond_to?(:type_for_attribute)
+            case klass.type_for_attribute(find_by)&.type&.to_sym
+            when :string
+              :string
+            else
+              :integer
+            end
           end
-        end
+        end 
       end
 
     end

--- a/lib/subroutine/type_caster.rb
+++ b/lib/subroutine/type_caster.rb
@@ -66,6 +66,7 @@ end
 ::Subroutine::TypeCaster.register :foreign_key do |value, options = {}|
   next nil if value.blank?
 
+  next ::Subroutine::TypeCaster.cast(value, type: options[:foreign_key_type].call) if options[:foreign_key_type].respond_to?(:call)
   next ::Subroutine::TypeCaster.cast(value, type: options[:foreign_key_type]) if options[:foreign_key_type]
   next ::Subroutine::TypeCaster.cast(value, type: :integer) if options[:name] && options[:name].to_s.end_with?("_id")
 


### PR DESCRIPTION
Update the foreign key type to be set dynamically on first call vs at boot time. This will allow the changes made in https://github.com/guideline-tech/subroutine/pull/35 to work in production environments where code is eager loaded.