### PR TITLE
Add support for Rails 6.1

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,7 @@
+## Subroutine 3.0
+
+Add support for Rails 6.1. Drop support for Rails 6.0 and lower.
+
 ## Subroutine 2.2
 
 Add `type` validation for Output.

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in subroutine.gemspec
 gemspec
 
-eval_gemfile "gemfiles/am60.gemfile"
+eval_gemfile "gemfiles/am61.gemfile"

--- a/gemfiles/am41.gemfile
+++ b/gemfiles/am41.gemfile
@@ -1,7 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec :path => '../'
-
-gem 'rack'
-gem 'activemodel', '~> 4.1.0'
-gem 'actionpack', '~> 4.1.0'

--- a/gemfiles/am42.gemfile
+++ b/gemfiles/am42.gemfile
@@ -1,7 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec :path => '../'
-
-gem 'rack'
-gem 'activemodel', '~> 4.2.0'
-gem 'actionpack', '~> 4.2.0'

--- a/gemfiles/am50.gemfile
+++ b/gemfiles/am50.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec :path => '../'
-
-gem 'activemodel', '~> 5.0.0'
-gem 'actionpack', '~> 5.0.0'

--- a/gemfiles/am51.gemfile
+++ b/gemfiles/am51.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec :path => '../'
-
-gem 'activemodel', '~> 5.1.0'
-gem 'actionpack', '~> 5.1.0'

--- a/gemfiles/am52.gemfile
+++ b/gemfiles/am52.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec :path => '../'
-
-gem 'activemodel', '~> 5.2.0'
-gem 'actionpack', '~> 5.2.0'

--- a/gemfiles/am60.gemfile
+++ b/gemfiles/am60.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec :path => '../'
-
-gem 'activemodel', '~> 6.0.0'
-gem 'actionpack', '~> 6.0.0'

--- a/gemfiles/am61.gemfile
+++ b/gemfiles/am61.gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gemspec :path => '../'
+
+gem 'activemodel', '~> 6.1.0'
+gem 'actionpack', '~> 6.1.0'

--- a/lib/subroutine/op.rb
+++ b/lib/subroutine/op.rb
@@ -112,9 +112,10 @@ module Subroutine
     end
 
     def inherit_errors(error_object, prefix: nil)
-      error_object = error_object.errors if error_object.respond_to?(:errors)
+      error_object = error_object.errors if error_object.respond_to?(:errors) && !error_object.is_a?(ActiveModel::Errors)
 
-      error_object.each do |field_name, error|
+      error_object.each do |error|
+        field_name = error.attribute
         field_name = "#{prefix}#{field_name}" if prefix
         field_name = field_name.to_sym
 
@@ -125,9 +126,9 @@ module Subroutine
         end
 
         if field_config
-          errors.add(field_config.field_name, error)
+          errors.add(field_config.field_name, error.message)
         else
-          errors.add(:base, error_object.full_message(field_name, error))
+          errors.add(:base, error_object.full_message(field_name, error.message))
         end
       end
 

--- a/lib/subroutine/version.rb
+++ b/lib/subroutine/version.rb
@@ -2,9 +2,9 @@
 
 module Subroutine
 
-  MAJOR = 2
-  MINOR = 3
-  PATCH = 2
+  MAJOR = 3
+  MINOR = 0
+  PATCH = 0
   PRE   = nil
 
   VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join(".")

--- a/subroutine.gemspec
+++ b/subroutine.gemspec
@@ -19,10 +19,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(gemfiles|test)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activemodel", ">= 4.0.0"
-  spec.add_dependency "activesupport", ">= 4.0.0"
+  spec.add_dependency "activemodel", ">= 6.1"
+  spec.add_dependency "activesupport", ">= 6.1"
 
-  spec.add_development_dependency "actionpack", ">= 4.0"
+  spec.add_development_dependency "actionpack", ">= 6.1"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "m"


### PR DESCRIPTION
The `ActiveModel::Errors` interface has changed in Rails 6.1. [More info here](https://code.lulalala.com/2020/0531-1013.html).

This PR adds support for Rails 6.1+ and drops support for Rails <=6.0. 