### PR TITLE
Fix bug with polymorphic associations

### DIFF
--- a/lib/subroutine/type_caster.rb
+++ b/lib/subroutine/type_caster.rb
@@ -65,9 +65,11 @@ end
 
 ::Subroutine::TypeCaster.register :foreign_key do |value, options = {}|
   next nil if value.blank?
-
-  next ::Subroutine::TypeCaster.cast(value, type: options[:foreign_key_type].call) if options[:foreign_key_type].respond_to?(:call)
-  next ::Subroutine::TypeCaster.cast(value, type: options[:foreign_key_type]) if options[:foreign_key_type]
+  
+  calculated_type = options[:foreign_key_type].respond_to?(:call)
+  calculated_value = calculated_type ? options[:foreign_key_type].call : options[:foreign_key_type]
+  
+  next ::Subroutine::TypeCaster.cast(value, type: calculated_value) if calculated_value
   next ::Subroutine::TypeCaster.cast(value, type: :integer) if options[:name] && options[:name].to_s.end_with?("_id")
 
   value

--- a/lib/subroutine/version.rb
+++ b/lib/subroutine/version.rb
@@ -4,7 +4,7 @@ module Subroutine
 
   MAJOR = 2
   MINOR = 3
-  PATCH = 1
+  PATCH = 2
   PRE   = nil
 
   VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join(".")

--- a/test/subroutine/association_test.rb
+++ b/test/subroutine/association_test.rb
@@ -231,6 +231,11 @@ module Subroutine
       assert_equal true, op.field_provided?(:admin_id)
       assert_equal true, op.field_provided?(:admin_type)
 
+      op = PolymorphicAssociationOp.new admin_type: doug.class.name, admin_id: doug.id.to_s
+      assert_equal true, op.field_provided?(:admin)
+      assert_equal true, op.field_provided?(:admin_id)
+      assert_equal true, op.field_provided?(:admin_type)
+
       op = PolymorphicAssociationOp.new admin_id: doug.id
       assert_equal false, op.field_provided?(:admin)
       assert_equal true, op.field_provided?(:admin_id)
@@ -291,6 +296,18 @@ module Subroutine
       op = PolymorphicAssociationOp.new(admin: user)
       op.admin
       assert_equal({ "admin_id" => 1, "admin_type" => "User" }, op.params)
+    end
+
+    def test_params_id_type_as_integer_for_polymorphic_associations
+      user = ::User.new(id: 1)
+
+      op = PolymorphicAssociationOp.new(admin_id: user.id)
+      op.admin
+      assert_equal({ "admin_id" => 1 }, op.params)
+
+      op = PolymorphicAssociationOp.new(admin_id: user.id.to_s)
+      op.admin
+      assert_equal({ "admin_id" => 1 }, op.params)
     end
 
     def test_params_can_be_accessed_with_associations_loaded


### PR DESCRIPTION
With polymorphic associations, the change in https://github.com/guideline-tech/subroutine/pull/37 resulted in us no longer hitting the auto-integer convert on line 71 if `options[:foreign_key_type].call` did not return a result (most commonly for polymorphic associations, but could also happen if the foreign type doesn't get properly inferred or if `type_for_attribute` isn't defined). This PR should reinstate that behavior.