### PR TITLE
TypeCaster documentation

### DIFF
--- a/lib/subroutine/type_caster.rb
+++ b/lib/subroutine/type_caster.rb
@@ -45,9 +45,16 @@ module Subroutine
     rescue StandardError => e
       raise ::Subroutine::TypeCaster::TypeCastError, e.to_s, e.backtrace
     end
+
   end
 end
 
+# Cast inputs to a number. By default, it will be cast to a float using #to_f.
+# If a `methods` option is passed, the specified methods will be iterated over
+# until the first method that the input responds to, and the number will be cast
+# using that method.
+#
+# @return [Number] - The cast value
 ::Subroutine::TypeCaster.register :number, :float do |value, options = {}|
   next nil if value.blank?
 

--- a/lib/subroutine/type_caster.rb
+++ b/lib/subroutine/type_caster.rb
@@ -96,6 +96,15 @@ end
   value
 end
 
+# Casts inputs to a String and then compares them with a set of true values. If
+# the String-cast version does not match an input, a false value is returned.
+# The set of truthy strings is:
+#   - true
+#   - yes
+#   - 1
+#   - ok
+#
+# @return [Boolean]
 ::Subroutine::TypeCaster.register :boolean, :bool do |value, _options = {}|
   !!(String(value) =~ /^(yes|true|1|ok)$/)
 end

--- a/lib/subroutine/type_caster.rb
+++ b/lib/subroutine/type_caster.rb
@@ -69,6 +69,10 @@ end
   ::Subroutine::TypeCaster.cast(value, type: :number, methods: [:to_i])
 end
 
+# Attempt to cast input to a BigDecimal value. If #to_d is not defined on the receiver,
+# casts to a float instead.
+#
+# @ return [BigDecimal, Float]
 ::Subroutine::TypeCaster.register :decimal, :big_decimal do |value, _options = {}|
   ::Subroutine::TypeCaster.cast(value, type: :number, methods: [:to_d, :to_f])
 end

--- a/lib/subroutine/type_caster.rb
+++ b/lib/subroutine/type_caster.rb
@@ -62,6 +62,9 @@ end
   meth ? value.send(meth) : value.to_f
 end
 
+# Cast inputs to an Integer
+#
+# @ return [Integer] - The cast value
 ::Subroutine::TypeCaster.register :integer, :int, :epoch do |value, _options = {}|
   ::Subroutine::TypeCaster.cast(value, type: :number, methods: [:to_i])
 end

--- a/lib/subroutine/type_caster.rb
+++ b/lib/subroutine/type_caster.rb
@@ -147,6 +147,10 @@ end
   ::Date.parse(String(value))
 end
 
+# Casts input to a Time object. The input must be able to be Stringified into a parseable
+# time string.
+#
+# @return [Date]
 ::Subroutine::TypeCaster.register :time, :timestamp, :datetime do |value, _options = {}|
   next nil unless value.present?
 

--- a/lib/subroutine/type_caster.rb
+++ b/lib/subroutine/type_caster.rb
@@ -179,6 +179,10 @@ end
   {}
 end
 
+# Casts input to an array. If the `of` option is provided, it will attempt to
+# cast each element of the array to the specified type.
+#
+# @ returns [Array]
 ::Subroutine::TypeCaster.register :array do |value, options = {}|
   next [] if value.blank?
 

--- a/lib/subroutine/type_caster.rb
+++ b/lib/subroutine/type_caster.rb
@@ -182,7 +182,7 @@ end
 # Casts input to an array. If the `of` option is provided, it will attempt to
 # cast each element of the array to the specified type.
 #
-# @ returns [Array]
+# @returns [Array]
 ::Subroutine::TypeCaster.register :array do |value, options = {}|
   next [] if value.blank?
 
@@ -191,6 +191,12 @@ end
   out
 end
 
+# Casts input to a Tempfile or File object. If the input is not already
+# a Tempfile or File, it is written to a new tempfile and the contents written
+# to said Tempfile. If the `base64` option is provided with a truthy value, the
+# input will be base64 decoded before being written.
+#
+# @returns [Tempfile, File]
 ::Subroutine::TypeCaster.register :file do |value, options = {}|
   next nil if value.blank?
 

--- a/lib/subroutine/type_caster.rb
+++ b/lib/subroutine/type_caster.rb
@@ -137,6 +137,10 @@ end
   t.utc.iso8601
 end
 
+# Casts input to a Date object. The input must be able to be Stringified into a parseable
+# date string.
+#
+# @return [Date]
 ::Subroutine::TypeCaster.register :date do |value, _options = {}|
   next nil unless value.present?
 

--- a/lib/subroutine/type_caster.rb
+++ b/lib/subroutine/type_caster.rb
@@ -160,7 +160,7 @@ end
 # Casts input to a Hash. If the input reponds to #to_hash, its internal implentation will
 # be used. ActionController::Parameters objects will be recursively cast hash values of that type.
 #
-# @return [Date]
+# @return [Hash]
 ::Subroutine::TypeCaster.register :hash, :object, :hashmap, :dict do |value, _options = {}|
   if value.class.name == 'ActionController::Parameters'
     value = value.to_hash

--- a/lib/subroutine/type_caster.rb
+++ b/lib/subroutine/type_caster.rb
@@ -77,6 +77,9 @@ end
   ::Subroutine::TypeCaster.cast(value, type: :number, methods: [:to_d, :to_f])
 end
 
+# Cast input to a string.
+#
+# @ return [String]
 ::Subroutine::TypeCaster.register :string, :text do |value, _options = {}|
   String(value)
 end

--- a/lib/subroutine/type_caster.rb
+++ b/lib/subroutine/type_caster.rb
@@ -123,6 +123,10 @@ end
   d.iso8601
 end
 
+# Casts input to a UTC, ISO-8601 String representation of the time. The input can be a Time,
+# Time-like, or a String representation of the time.
+#
+# @return [String] - ISO-8601 representation of the input
 ::Subroutine::TypeCaster.register :iso_time do |value, _options = {}|
   next nil unless value.present?
 

--- a/lib/subroutine/type_caster.rb
+++ b/lib/subroutine/type_caster.rb
@@ -109,6 +109,10 @@ end
   !!(String(value) =~ /^(yes|true|1|ok)$/)
 end
 
+# Casts input to an ISO-8601 String representation of the date. The input can be a Date,
+# Date-like, or a String representation of a date.
+#
+# @return [String] - ISO-8601 representation of the input.
 ::Subroutine::TypeCaster.register :iso_date do |value, _options = {}|
   next nil unless value.present?
 

--- a/lib/subroutine/type_caster.rb
+++ b/lib/subroutine/type_caster.rb
@@ -9,6 +9,10 @@ require 'active_support/core_ext/object/try'
 require 'active_support/core_ext/array/wrap'
 
 module Subroutine
+  # Registers named types for explicitly casting Op inputs to known types.
+  #
+  # It is important to note that TypeCaster does not implicitlyvalidate types
+  # and Op validations are run against the cast values, not the original inputs.
   module TypeCaster
 
     class TypeCastError < StandardError

--- a/lib/subroutine/type_caster.rb
+++ b/lib/subroutine/type_caster.rb
@@ -157,6 +157,10 @@ end
   ::Time.parse(String(value))
 end
 
+# Casts input to a Hash. If the input reponds to #to_hash, its internal implentation will
+# be used. ActionController::Parameters objects will be recursively cast hash values of that type.
+#
+# @return [Date]
 ::Subroutine::TypeCaster.register :hash, :object, :hashmap, :dict do |value, _options = {}|
   if value.class.name == 'ActionController::Parameters'
     value = value.to_hash


### PR DESCRIPTION
Added documentation to most of the types registered to TypeCaster. 

I've seen confusion in the past about the behavior of the module - this is an attempt to help people understand what's going on a little better, i.e. what it _is_ doing and what it _isn't_ doing. Most of the information can be gleaned from a quick scan of the code, but I still saw people thinking it was enforcing typing for one reason or another.

The only one I omitted documentation for was the `foreign_key`. I'm pretty sure I understand what it's doing, but comparing the tests to the registration logic left me with just enough questions that I didn't want to try to document it myself.