### PR TITLE
Allow configuration of default params behaviors

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,6 +2,8 @@
 
 The `Subroutine::Fields` module now contains a class_attribute that allows the altering of param accessor behaviors. `include_defaults_in_params` is now available to opt into including the default values in usage of the `all_params (alias params)` method. Backwards compatibility is preserved by defaulting the value to `false`. If switched to true, when an input is omitted and the field is configured with a default value, it will be included in the `all_params` object.
 
+Removed all usage of `ungrouped` params and refactored the storage of grouped params. Params are now stored in either the provided group or the defaults group and accessed via provided_params, params, default_params, and params_with_defaults. Grouped params are acessed the same way but with the group name prefixed eg. `my_private_default_params`.
+
 ## Subroutine 3.0
 
 Add support for Rails 6.1. Drop support for Rails 6.0 and lower.

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,4 +1,4 @@
-## Subroutine 3.1
+## Subroutine 4.0
 
 The `Subroutine::Fields` module now contains a class_attribute that allows the altering of param accessor behaviors. `include_defaults_in_params` is now available to opt into including the default values in usage of the `all_params (alias params)` method. Backwards compatibility is preserved by defaulting the value to `false`. If switched to true, when an input is omitted and the field is configured with a default value, it will be included in the `all_params` object.
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -2,7 +2,7 @@
 
 The `Subroutine::Fields` module now contains a class_attribute that allows the altering of param accessor behaviors. `include_defaults_in_params` is now available to opt into including the default values in usage of the `all_params (alias params)` method. Backwards compatibility is preserved by defaulting the value to `false`. If switched to true, when an input is omitted and the field is configured with a default value, it will be included in the `all_params` object.
 
-Removed all usage of `ungrouped` params and refactored the storage of grouped params. Params are now stored in either the provided group or the defaults group and accessed via provided_params, params, default_params, and params_with_defaults. Grouped params are acessed the same way but with the group name prefixed eg. `my_private_default_params`.
+Removed all usage of `ungrouped` params and refactored the storage of grouped params. Params are now stored in either the provided group or the defaults group and accessed via provided_params, params, default_params, and params_with_defaults. Grouped params are accessed the same way but with the group name prefixed eg. `my_private_default_params`.
 
 ## Subroutine 3.0
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,6 +1,14 @@
+## Subroutine 3.1
+
+The `Subroutine::Fields` module now contains a class_attribute that allows the altering of param accessor behaviors. `include_defaults_in_params` is now available to opt into including the default values in usage of the `all_params (alias params)` method. Backwards compatibility is preserved by defaulting the value to `false`. If switched to true, when an input is omitted and the field is configured with a default value, it will be included in the `all_params` object.
+
 ## Subroutine 3.0
 
 Add support for Rails 6.1. Drop support for Rails 6.0 and lower.
+
+## Subroutine 2.3
+
+Support dynamic types for foreign keys on association fields. The class type is used at runtime to determine the casting behavior of the foreign key field.
 
 ## Subroutine 2.2
 

--- a/lib/subroutine.rb
+++ b/lib/subroutine.rb
@@ -3,3 +3,17 @@
 require "subroutine/version"
 require "subroutine/fields"
 require "subroutine/op"
+
+module Subroutine
+
+  def self.include_defaults_in_params=(bool)
+    @include_defaults_in_params = !!bool
+  end
+
+  def self.include_defaults_in_params?
+    return !!@include_defaults_in_params if defined?(@instance_defaults_in_params)
+
+    false
+  end
+
+end

--- a/lib/subroutine.rb
+++ b/lib/subroutine.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
-require "delegate"
-
+require "active_model"
 require "active_support/concern"
-require "active_support/core_ext/object/duplicable"
 require "active_support/core_ext/hash/indifferent_access"
-require "active_support/core_ext/object/deep_dup"
 require "active_support/core_ext/module/redefine_method"
+require "active_support/core_ext/object/deep_dup"
+require "active_support/core_ext/object/duplicable"
+require "active_support/core_ext/string/inflections"
+require "delegate"
 
 require "subroutine/version"
 require "subroutine/fields"

--- a/lib/subroutine.rb
+++ b/lib/subroutine.rb
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 
+require "delegate"
+
+require "active_support/concern"
+require "active_support/core_ext/object/duplicable"
+require "active_support/core_ext/hash/indifferent_access"
+require "active_support/core_ext/object/deep_dup"
+require "active_support/core_ext/module/redefine_method"
+
 require "subroutine/version"
 require "subroutine/fields"
 require "subroutine/op"

--- a/lib/subroutine/association_fields.rb
+++ b/lib/subroutine/association_fields.rb
@@ -113,20 +113,20 @@ module Subroutine
       out
     end
 
-    def set_field_with_association(field_name, value, opts = {})
+    def set_field_with_association(field_name, value, **opts)
       config = get_field_config(field_name)
 
       if config&.behavior == :association
         maybe_raise_on_association_type_mismatch!(config, value)
-        set_field(config.foreign_type_method, value&.class&.name, opts) if config.polymorphic?
-        set_field(config.foreign_key_method, value&.send(config.find_by), opts)
+        set_field(config.foreign_type_method, value&.class&.name, **opts) if config.polymorphic?
+        set_field(config.foreign_key_method, value&.send(config.find_by), **opts)
         association_cache[config.field_name] = value
       else
         if config&.behavior == :association_component
           clear_field_without_association(config.association_name)
         end
 
-        set_field_without_association(field_name, value, opts)
+        set_field_without_association(field_name, value, **opts)
       end
     end
 

--- a/lib/subroutine/association_fields.rb
+++ b/lib/subroutine/association_fields.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "delegate"
-require "active_support/concern"
 require "subroutine/association_fields/configuration"
 require "subroutine/association_fields/association_type_mismatch_error"
 
@@ -72,8 +70,7 @@ module Subroutine
             field config.foreign_type_method, config.build_foreign_type_field
           else
             class_eval <<-EV, __FILE__, __LINE__ + 1
-              try(:silence_redefinition_of_method, :#{config.foreign_type_method})
-              def #{config.foreign_type_method}
+              silence_redefinition_of_method def #{config.foreign_type_method}
                 #{config.inferred_foreign_type.inspect}
               end
             EV
@@ -180,7 +177,7 @@ module Subroutine
           get_field(config.foreign_type_method)
         end
 
-      klass = klass.classify.constantize if klass.is_a?(String)
+      klass = klass.camelize.constantize if klass.is_a?(String)
       return nil unless klass
 
       foreign_key = config.foreign_key_method

--- a/lib/subroutine/fields.rb
+++ b/lib/subroutine/fields.rb
@@ -111,9 +111,9 @@ module Subroutine
       def ensure_group_accessors(group_name)
         class_eval <<-EV, __FILE__, __LINE__ + 1
           silence_redefinition_of_method def #{group_name}_params
-            include_defaults_in_params? ?
-              #{group_name}_params_with_defaults :
-              #{group_name}_provided_params
+            return #{group_name}_params_with_defaults if include_defaults_in_params?
+
+            #{group_name}_provided_params
           end
 
           silence_redefinition_of_method def #{group_name}_provided_params
@@ -210,11 +210,9 @@ module Subroutine
     alias default_params all_default_params
 
     def all_params
-      if include_defaults_in_params?
-        all_params_with_default_params
-      else
-        all_provided_params
-      end
+      return all_params_with_default_params if include_defaults_in_params?
+
+      all_provided_params
     end
     alias params all_params
 

--- a/lib/subroutine/fields.rb
+++ b/lib/subroutine/fields.rb
@@ -202,6 +202,7 @@ module Subroutine
       get_param_group(:default)
     end
     alias defaults all_default_params
+    alias default_params all_default_params
 
     def all_params
       if include_defaults_in_params

--- a/lib/subroutine/fields.rb
+++ b/lib/subroutine/fields.rb
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/concern"
-require "active_support/core_ext/object/duplicable"
-require "active_support/core_ext/hash/indifferent_access"
-require "active_support/core_ext/object/deep_dup"
-
 require "subroutine/type_caster"
 require "subroutine/fields/configuration"
 require "subroutine/fields/mass_assignment_error"

--- a/lib/subroutine/fields/configuration.rb
+++ b/lib/subroutine/fields/configuration.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "delegate"
-
 module Subroutine
   module Fields
     class Configuration < ::SimpleDelegator

--- a/lib/subroutine/op.rb
+++ b/lib/subroutine/op.rb
@@ -49,8 +49,7 @@ module Subroutine
     end
 
     def inspect
-      values = provided_params.to_a
-      values.map! do |(key, value)|
+      values = provided_params.map do |(key, value)|
         "#{key}: #{value.inspect}"
       end
       values.sort!

--- a/lib/subroutine/op.rb
+++ b/lib/subroutine/op.rb
@@ -48,6 +48,18 @@ module Subroutine
       yield self if block_given?
     end
 
+    def inspect
+      values = provided_params.to_a
+      values.map! do |(key, value)|
+        "#{key}: #{value.inspect}"
+      end
+      values.sort!
+      values = values.join(", ")
+
+      oid = format('%x', (object_id << 1))
+      "#<#{self.class}:0x#{oid} #{values}>"
+    end
+
     def submit!
       begin
         observe_submission do

--- a/lib/subroutine/op.rb
+++ b/lib/subroutine/op.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "active_model"
-
 require "subroutine/failure"
 require "subroutine/fields"
 require "subroutine/outputs"

--- a/lib/subroutine/outputs.rb
+++ b/lib/subroutine/outputs.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "active_support/concern"
 require "subroutine/outputs/configuration"
 require "subroutine/outputs/output_not_set_error"
 require "subroutine/outputs/unknown_output_error"

--- a/lib/subroutine/outputs/configuration.rb
+++ b/lib/subroutine/outputs/configuration.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "delegate"
-
 module Subroutine
   module Outputs
     class Configuration < ::SimpleDelegator

--- a/lib/subroutine/version.rb
+++ b/lib/subroutine/version.rb
@@ -3,8 +3,8 @@
 module Subroutine
 
   MAJOR = 3
-  MINOR = 0
-  PATCH = 2
+  MINOR = 1
+  PATCH = 0
   PRE   = nil
 
   VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join(".")

--- a/lib/subroutine/version.rb
+++ b/lib/subroutine/version.rb
@@ -5,7 +5,7 @@ module Subroutine
   MAJOR = 3
   MINOR = 1
   PATCH = 0
-  PRE   = nil
+  PRE   = "alpha"
 
   VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join(".")
 

--- a/lib/subroutine/version.rb
+++ b/lib/subroutine/version.rb
@@ -2,8 +2,8 @@
 
 module Subroutine
 
-  MAJOR = 3
-  MINOR = 1
+  MAJOR = 4
+  MINOR = 0
   PATCH = 0
   PRE   = "alpha"
 

--- a/test/subroutine/base_test.rb
+++ b/test/subroutine/base_test.rb
@@ -318,5 +318,11 @@ module Subroutine
       assert_equal raw_params, op.params
     end
 
+    def test_inspect_is_pretty
+      op = SignupOp.new({ email: "foo@bar.com", password: "password123!" })
+      oid = format('%x', (op.object_id << 1))
+      assert_equal "#<SignupOp:0x#{oid} email: \"foo@bar.com\", password: \"password123!\">", op.inspect
+    end
+
   end
 end

--- a/test/subroutine/fields_test.rb
+++ b/test/subroutine/fields_test.rb
@@ -85,7 +85,18 @@ module Subroutine
       assert_equal({ "foo" => "abc", "bar" => 3, "qux" => "qux" }, instance.params_with_defaults)
     end
 
+    def test_params_include_defaults_if_globally_configured
+      Subroutine.stubs(:include_defaults_in_params?).returns(true)
+      instance = Whatever.new(foo: "abc")
+      assert Whatever.include_defaults_in_params?
+      assert_equal({ "foo" => "abc" }, instance.provided_params)
+      assert_equal({ "foo" => "foo", "bar" => 3, "qux" => "qux" }, instance.defaults)
+      assert_equal({ "foo" => "abc", "bar" => 3, "qux" => "qux" }, instance.params)
+      assert_equal({ "foo" => "abc", "bar" => 3, "qux" => "qux" }, instance.params_with_defaults)
+    end
+
     def test_params_includes_defaults_if_opted_into
+      refute Subroutine.include_defaults_in_params?
       instance = WhateverWithDefaultsIncluded.new(foo: "abc")
       assert_equal({ "foo" => "abc" }, instance.provided_params)
       assert_equal({ "foo" => "foo", "bar" => 3, "qux" => "qux" }, instance.defaults)

--- a/test/subroutine/fields_test.rb
+++ b/test/subroutine/fields_test.rb
@@ -145,7 +145,6 @@ module Subroutine
       op = Whatever.new(foo: "bar", protekted_group_input: "pgi", bar: 8)
       assert_equal({ protekted_group_input: "pgi", bar: 8 }.with_indifferent_access, op.sekret_params)
       assert_equal({ protekted_group_input: "pgi", foo: "bar", bar: 8 }.with_indifferent_access, op.params)
-      assert_equal({ foo: "bar" }.with_indifferent_access, op.ungrouped_params)
     end
 
     def test_fields_from_allows_merging_of_config

--- a/test/subroutine/fields_test.rb
+++ b/test/subroutine/fields_test.rb
@@ -168,14 +168,14 @@ module Subroutine
 
     def test_set_field_can_add_to_the_default_params
       instance = Whatever.new
-      instance.set_field(:foo, "bar", provided: false)
+      instance.set_field(:foo, "bar", group_type: :default)
       assert_equal false, instance.provided_params.key?(:foo)
       assert_equal "bar", instance.default_params[:foo]
     end
 
     def test_group_fields_are_accessible_at_the_class
-      results = Whatever.field_groups[:sekret].sort
-      assert_equal %i[bar protekted_group_input], results
+      fields = Whatever.fields_by_group[:sekret].sort
+      assert_equal %i[bar protekted_group_input], fields
     end
 
     def test_groups_fields_are_accessible
@@ -206,12 +206,12 @@ module Subroutine
     end
 
     def test_group_fields_are_not_mutated_by_subclasses
-      assert_equal(%i[three_letter], MutationBase.field_groups.keys.sort)
-      assert_equal(%i[four_letter three_letter], MutationChild.field_groups.keys.sort)
+      assert_equal(%i[three_letter], MutationBase.fields_by_group.keys.sort)
+      assert_equal(%i[four_letter three_letter], MutationChild.fields_by_group.keys.sort)
 
-      assert_equal(%i[bar foo], MutationBase.field_groups[:three_letter].sort)
-      assert_equal(%i[bar foo qux], MutationChild.field_groups[:three_letter].sort)
-      assert_equal(%i[food], MutationChild.field_groups[:four_letter].sort)
+      assert_equal(%i[bar foo], MutationBase.fields_by_group[:three_letter].sort)
+      assert_equal(%i[bar foo qux], MutationChild.fields_by_group[:three_letter].sort)
+      assert_equal(%i[food], MutationChild.fields_by_group[:four_letter].sort)
     end
 
   end

--- a/test/subroutine/fields_test.rb
+++ b/test/subroutine/fields_test.rb
@@ -25,6 +25,10 @@ module Subroutine
 
     end
 
+    class WhateverWithDefaultsIncluded < Whatever
+      self.include_defaults_in_params = true
+    end
+
     def test_fields_are_configured
       assert_equal 6, Whatever.field_configurations.size
       assert_equal :string, Whatever.field_configurations[:foo][:type]
@@ -75,14 +79,31 @@ module Subroutine
 
     def test_params_does_not_include_defaults
       instance = Whatever.new(foo: "abc")
+      assert_equal({ "foo" => "abc" }, instance.provided_params)
       assert_equal({ "foo" => "foo", "bar" => 3, "qux" => "qux" }, instance.defaults)
       assert_equal({ "foo" => "abc" }, instance.params)
       assert_equal({ "foo" => "abc", "bar" => 3, "qux" => "qux" }, instance.params_with_defaults)
     end
 
-    def test_named_params_do_not_include_defaults_unlesss_asked_for
+    def test_params_includes_defaults_if_opted_into
+      instance = WhateverWithDefaultsIncluded.new(foo: "abc")
+      assert_equal({ "foo" => "abc" }, instance.provided_params)
+      assert_equal({ "foo" => "foo", "bar" => 3, "qux" => "qux" }, instance.defaults)
+      assert_equal({ "foo" => "abc", "bar" => 3, "qux" => "qux" }, instance.params)
+      assert_equal({ "foo" => "abc", "bar" => 3, "qux" => "qux" }, instance.params_with_defaults)
+    end
+
+    def test_named_params_do_not_include_defaults_unless_asked_for
       instance = Whatever.new(foo: "abc")
+      assert_equal({}, instance.sekret_provided_params)
       assert_equal({}, instance.sekret_params)
+      assert_equal({ "bar" => 3 }, instance.sekret_params_with_defaults)
+    end
+
+    def test_named_params_include_defaults_if_configured
+      instance = WhateverWithDefaultsIncluded.new(foo: "abc")
+      assert_equal({}, instance.sekret_provided_params)
+      assert_equal({ "bar" => 3 }, instance.sekret_params)
       assert_equal({ "bar" => 3 }, instance.sekret_params_with_defaults)
     end
 

--- a/test/subroutine/fields_test.rb
+++ b/test/subroutine/fields_test.rb
@@ -134,6 +134,19 @@ module Subroutine
       assert_equal "bar", instance.foo
     end
 
+    def test_set_field_adds_to_provided_params
+      instance = Whatever.new
+      instance.set_field(:foo, "bar")
+      assert_equal true, instance.provided_params.key?(:foo)
+    end
+
+    def test_set_field_can_add_to_the_default_params
+      instance = Whatever.new
+      instance.set_field(:foo, "bar", provided: false)
+      assert_equal false, instance.provided_params.key?(:foo)
+      assert_equal "bar", instance.default_params[:foo]
+    end
+
     def test_group_fields_are_accessible_at_the_class
       results = Whatever.fields_in_group(:sekret)
       assert_equal true, results.key?(:protekted_group_input)


### PR DESCRIPTION
The `Subroutine::Fields` module now contains a class_attribute that allows the altering of param accessor behaviors. `include_defaults_in_params` is now available to opt into including the default values in usage of the `all_params (alias params)` method. Backwards compatibility is preserved by defaulting the value to `false`. If switched to true, when an input is omitted and the field is configured with a default value, it will be included in the `all_params` object.