### PR TITLE
Make it so observe_submission wraps output validation as well

### DIFF
--- a/lib/subroutine/op.rb
+++ b/lib/subroutine/op.rb
@@ -49,25 +49,25 @@ module Subroutine
     end
 
     def submit!
-      begin
-        observe_submission do
+      observe_submission do
+        begin
           validate_and_perform
+        rescue Exception => e
+          if e.respond_to?(:record)
+            inherit_errors(e.record) unless e.record == self
+            new_e = _failure_class.new(self)
+            raise new_e, new_e.message, e.backtrace
+          else
+            raise
+          end
         end
-      rescue Exception => e
-        if e.respond_to?(:record)
-          inherit_errors(e.record) unless e.record == self
-          new_e = _failure_class.new(self)
-          raise new_e, new_e.message, e.backtrace
-        else
-          raise
-        end
-      end
 
-      if errors.empty?
-        validate_outputs!
-        self
-      else
-        raise _failure_class, self
+        if errors.empty?
+          validate_outputs!
+          self
+        else
+          raise _failure_class, self
+        end
       end
     end
 

--- a/lib/subroutine/version.rb
+++ b/lib/subroutine/version.rb
@@ -3,8 +3,8 @@
 module Subroutine
 
   MAJOR = 2
-  MINOR = 3
-  PATCH = 2
+  MINOR = 4
+  PATCH = 0
   PRE   = nil
 
   VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join(".")

--- a/test/subroutine/base_test.rb
+++ b/test/subroutine/base_test.rb
@@ -318,5 +318,11 @@ module Subroutine
       assert_equal raw_params, op.params
     end
 
+    def test_nooping_observe_submission_doesnt_validate_outputs
+      op = NoObserveSubmissionOp.new
+      op.submit!
+      assert op.errors.blank?
+    end
+
   end
 end

--- a/test/support/ops.rb
+++ b/test/support/ops.rb
@@ -510,3 +510,11 @@ class PrefixedInputsOp < ::Subroutine::Op
   end
 
 end
+
+class NoObserveSubmissionOp < ::Subroutine::Op
+
+  outputs :foo
+
+  def observe_submission(*); end
+
+end


### PR DESCRIPTION
Make is so observe_submission wraps output validation as well, so that if we're deciding to skip submission by no-oping it, output validation doesn't happen.