### PR TITLE
Remove Ruby 2.7.7 from matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: [2.7.7, 2.7.8]
+        ruby-version: [2.7.8]
         experimental: [false]
         include:
           - ruby-version: 3.0


### PR DESCRIPTION
no longer needed as not latest 2.7