### PR TITLE
Dont use ruby stdlib #to_d and opt for a custom implementation instead

### DIFF
--- a/lib/subroutine/type_caster.rb
+++ b/lib/subroutine/type_caster.rb
@@ -56,7 +56,17 @@ end
 end
 
 ::Subroutine::TypeCaster.register :decimal, :big_decimal do |value, _options = {}|
-  ::Subroutine::TypeCaster.cast(value, type: :number, methods: [:to_d, :to_f])
+  next nil if value.blank?
+
+  if value.respond_to?(:to_d)
+    begin
+      next BigDecimal(value.to_s, 0)
+    rescue ArgumentError
+      BigDecimal(0)
+    end
+  end
+
+  ::Subroutine::TypeCaster.cast(value, type: :number, methods: [:to_f])
 end
 
 ::Subroutine::TypeCaster.register :string, :text do |value, _options = {}|
@@ -65,10 +75,10 @@ end
 
 ::Subroutine::TypeCaster.register :foreign_key do |value, options = {}|
   next nil if value.blank?
-  
+
   calculated_type = options[:foreign_key_type].respond_to?(:call)
   calculated_value = calculated_type ? options[:foreign_key_type].call : options[:foreign_key_type]
-  
+
   next ::Subroutine::TypeCaster.cast(value, type: calculated_value) if calculated_value
   next ::Subroutine::TypeCaster.cast(value, type: :integer) if options[:name] && options[:name].to_s.end_with?("_id")
 

--- a/lib/subroutine/type_caster.rb
+++ b/lib/subroutine/type_caster.rb
@@ -62,7 +62,7 @@ end
     begin
       next BigDecimal(value.to_s, 0)
     rescue ArgumentError
-      BigDecimal(0)
+      next BigDecimal(0)
     end
   end
 

--- a/lib/subroutine/version.rb
+++ b/lib/subroutine/version.rb
@@ -4,7 +4,7 @@ module Subroutine
 
   MAJOR = 3
   MINOR = 0
-  PATCH = 0
+  PATCH = 1
   PRE   = nil
 
   VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join(".")

--- a/test/subroutine/type_caster_test.rb
+++ b/test/subroutine/type_caster_test.rb
@@ -42,6 +42,32 @@ module Subroutine
       assert_equal 0.0, op.number_input
     end
 
+    def test_decimal_inputs
+      op.decimal_input = nil
+      assert_nil op.decimal_input
+
+      op.decimal_input = 4
+      assert_equal 4.0, op.decimal_input
+      assert op.decimal_input.is_a?(BigDecimal)
+
+      op.decimal_input = 0.5
+      assert_equal 0.5, op.decimal_input
+
+      op.decimal_input = 'foo'
+      assert_equal 0.0, op.decimal_input
+    end
+
+    def test_decimal_inputs_use_16_precision
+      op.decimal_input = 0.07
+      assert_equal BigDecimal('0.07', 0), op.decimal_input
+      assert op.decimal_input.is_a?(BigDecimal)
+
+      # Ruby 3+
+      if op.decimal_input.respond_to?(:precision)
+        assert_equal 1, op.decimal_input.precision
+      end
+    end
+
     def test_string_inputs
       op.string_input = nil
       assert_nil op.string_input

--- a/test/subroutine/type_caster_test.rb
+++ b/test/subroutine/type_caster_test.rb
@@ -59,12 +59,13 @@ module Subroutine
 
     def test_decimal_inputs_use_16_precision
       op.decimal_input = 0.07
-      assert_equal BigDecimal('0.07', 0), op.decimal_input
+      expected_bd_value = BigDecimal('0.07', 0)
+      assert_equal expected_bd_value, op.decimal_input
       assert op.decimal_input.is_a?(BigDecimal)
 
       # Ruby 3+
       if op.decimal_input.respond_to?(:precision)
-        assert_equal 1, op.decimal_input.precision
+        assert_equal expected_bd_value.precision, op.decimal_input.precision
       end
     end
 


### PR DESCRIPTION
See
https://github.com/ruby/bigdecimal/commit/aa536cd4b585ff6045cf91f396bc3eef993b91f2

Unfortunately this was released in 3.1.4 and doesn't appear to be backported into ruby 3.0.X