### PR TITLE
Updating typecaster for boolean to be case insensitive

### DIFF
--- a/lib/subroutine/type_caster.rb
+++ b/lib/subroutine/type_caster.rb
@@ -86,7 +86,7 @@ end
 end
 
 ::Subroutine::TypeCaster.register :boolean, :bool do |value, _options = {}|
-  !!(String(value) =~ /^(yes|true|1|ok)$/)
+  !!(String(value) =~ /^(yes|true|1|ok)$/i)
 end
 
 ::Subroutine::TypeCaster.register :iso_date do |value, _options = {}|

--- a/test/subroutine/type_caster_test.rb
+++ b/test/subroutine/type_caster_test.rb
@@ -96,13 +96,43 @@ module Subroutine
       op.boolean_input = 'no'
       assert_equal false, op.boolean_input
 
+      op.boolean_input = 'Yes'
+      assert_equal true, op.boolean_input
+
+      op.boolean_input = 'No'
+      assert_equal false, op.boolean_input
+
+      op.boolean_input = 'YES'
+      assert_equal true, op.boolean_input
+
+      op.boolean_input = 'NO'
+      assert_equal false, op.boolean_input
+
       op.boolean_input = 'true'
       assert_equal true, op.boolean_input
 
       op.boolean_input = 'false'
       assert_equal false, op.boolean_input
 
+      op.boolean_input = 'True'
+      assert_equal true, op.boolean_input
+
+      op.boolean_input = 'False'
+      assert_equal false, op.boolean_input
+
+      op.boolean_input = 'TRUE'
+      assert_equal true, op.boolean_input
+
+      op.boolean_input = 'FALSE'
+      assert_equal false, op.boolean_input
+
       op.boolean_input = 'ok'
+      assert_equal true, op.boolean_input
+
+      op.boolean_input = 'OK'
+      assert_equal true, op.boolean_input
+
+      op.boolean_input = 'Ok'
       assert_equal true, op.boolean_input
 
       op.boolean_input = ''


### PR DESCRIPTION
Values like "TRUE" and "FALSE" should be properly converted to the appropriate boolean. 