### PR TITLE
chore(deps): bump bundler and rubygems 

### DIFF
--- a/gemfiles/rails_6.1.gemfile.lock
+++ b/gemfiles/rails_6.1.gemfile.lock
@@ -101,4 +101,4 @@ DEPENDENCIES
   subroutine!
 
 BUNDLED WITH
-   2.5.16
+   2.5.17

--- a/gemfiles/rails_7.0.gemfile.lock
+++ b/gemfiles/rails_7.0.gemfile.lock
@@ -99,4 +99,4 @@ DEPENDENCIES
   subroutine!
 
 BUNDLED WITH
-   2.5.16
+   2.5.17


### PR DESCRIPTION
- **Bundler 2.5.17 to match other repositories**
