### PR TITLE
Time caster now returns input value if it acts like a time object

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,9 @@
+## Subroutine 4.1.1
+
+Fields using the time/timestamp/datetime caster will now return exactly the passed in value
+if it acts like a time object (`acts_like?(:time)`/`acts_like_time?`), instead of serializing
+to string and re-parsing to a Time object. This fixes issues with losing usec precision.
+
 ## Subroutine 4.1.0
 
 A field can no opt out of the natural assignment behavior of ActiveSupport::HashWithIndifferentAccess. Top level param groups are still accessible via indifferent access but if a field sets the `bypass_indifferent_assignment` option to `true` the HashWithIndifferentAccess assignment behavior will be bypassed in favor of direct Hash-like assignment.

--- a/lib/subroutine/type_caster.rb
+++ b/lib/subroutine/type_caster.rb
@@ -4,9 +4,11 @@ require 'date'
 require 'time'
 require 'bigdecimal'
 require 'securerandom'
+require 'active_support/core_ext/object/acts_like'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/object/try'
 require 'active_support/core_ext/array/wrap'
+require 'active_support/core_ext/time/acts_like'
 
 module Subroutine
   module TypeCaster
@@ -118,7 +120,11 @@ end
 ::Subroutine::TypeCaster.register :time, :timestamp, :datetime do |value, _options = {}|
   next nil unless value.present?
 
-  ::Time.parse(String(value))
+  if value.try(:acts_like?, :time)
+    value
+  else
+    ::Time.parse(String(value))
+  end
 end
 
 ::Subroutine::TypeCaster.register :hash, :object, :hashmap, :dict do |value, _options = {}|

--- a/lib/subroutine/version.rb
+++ b/lib/subroutine/version.rb
@@ -4,7 +4,7 @@ module Subroutine
 
   MAJOR = 4
   MINOR = 1
-  PATCH = 0
+  PATCH = 1
   PRE   = nil
 
   VERSION = [MAJOR, MINOR, PATCH, PRE].compact.join(".")

--- a/test/subroutine/type_caster_test.rb
+++ b/test/subroutine/type_caster_test.rb
@@ -284,7 +284,7 @@ module Subroutine
       assert_equal 0, op.time_input.min
       assert_equal 0, op.time_input.sec
 
-      op.time_input = '2023-05-05T10:00:30Z'
+      op.time_input = '2023-05-05T10:00:30.123456Z'
       assert_equal ::Time, op.time_input.class
       refute_equal ::DateTime, op.time_input.class
 
@@ -294,6 +294,12 @@ module Subroutine
       assert_equal 10, op.time_input.hour
       assert_equal 0, op.time_input.min
       assert_equal 30, op.time_input.sec
+      assert_equal 123456, op.time_input.usec
+
+      time = Time.at(1678741605.123456)
+      op.time_input = time
+      assert_equal time, op.time_input
+      assert_equal time.object_id, op.time_input.object_id
     end
 
     def test_iso_date_inputs


### PR DESCRIPTION
Fields using the time/timestamp/datetime caster will now return exactly the passed in value
if it acts like a time object (`acts_like?(:time)`/`acts_like_time?`), instead of serializing
to string and re-parsing to a Time object. This fixes issues with losing usec precision.