### PR TITLE
add lazy option to outputs to delay execution of output if not needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ class SignupOp < ::Subroutine::Op
 
   outputs :user
   outputs :business, type: Business # validate that output type is an instance of Business
+  outputs :heavy_operation, lazy: true # delay the execution of the output until accessed
 
   protected
 
@@ -33,6 +34,7 @@ class SignupOp < ::Subroutine::Op
 
     output :user, u
     output :business, b
+    output :heavy_operation, -> { some_heavy_operation }
   end
 
   def create_user!
@@ -41,7 +43,11 @@ class SignupOp < ::Subroutine::Op
 
   def create_business!(owner)
     Business.create!(company_name: company_name, owner: owner)
-   end
+  end
+
+  def some_heavy_operation
+    # ...
+  end
 
   def deliver_welcome_email(u)
     UserMailer.welcome(u.id).deliver_later

--- a/lib/subroutine/outputs/configuration.rb
+++ b/lib/subroutine/outputs/configuration.rb
@@ -13,7 +13,10 @@ module Subroutine
         end
       end
 
-      DEFAULT_OPTIONS = { required: true }.freeze
+      DEFAULT_OPTIONS = {
+        required: true,
+        lazy: false
+      }.freeze
 
       attr_reader :output_name
 
@@ -26,6 +29,10 @@ module Subroutine
 
       def required?
         !!config[:required]
+      end
+
+      def lazy?
+        !!config[:lazy]
       end
 
       def inspect


### PR DESCRIPTION
## What

Add lazy option to outputs to delay execution of output if not needed in all situation where the op is called.

**Example:**

```ruby
class MyOp < ::Subroutine::Op

  outputs :heavy_operation, lazy: true

  protected

  def perform
    output :heavy_operation, -> { some_heavy_operation }
  end

  def some_heavy_operation
    # ...
  end

end
```

