### PR TITLE
include both type and message when inheriting field-level errors

### DIFF
--- a/lib/subroutine/op.rb
+++ b/lib/subroutine/op.rb
@@ -135,7 +135,7 @@ module Subroutine
         end
 
         if field_config
-          errors.add(field_config.field_name, error.message)
+          errors.add(field_config.field_name, error.type, message: error.message)
         else
           errors.add(:base, error_object.full_message(field_name, error.message))
         end

--- a/test/subroutine/base_test.rb
+++ b/test/subroutine/base_test.rb
@@ -127,6 +127,15 @@ module Subroutine
       assert_equal ["has gotta be @admin.com"], op.errors[:email]
     end
 
+    def test_validation_errors_can_be_inherited_with_both_type_and_message
+      op = ::AdminSignupOp.new(password: "password123")
+
+      refute op.submit
+
+      assert op.errors.added?(:email, :blank)
+      assert_equal ["can't be blank"], op.errors[:email]
+    end
+
     def test_validation_errors_can_be_inherited_and_prefixed
       op = PrefixedInputsOp.new(user_email_address: "foo@bar.com")
       refute op.submit


### PR DESCRIPTION
Include both type and message when inheriting field-level errors.

This can be useful in situations where we might want to query the errors without having to consider the full message. For example:

```
begin
  ::SignupOp.submit!(email: nil)
rescue Subroutine::Failure => e
  if e.record.errors.added?(:email, :blank)
    # some special handling of the error here...
  end
end
```