### PR TITLE
Fix Ruby 3.4 block-may-be-ignored warning in Op.submit!/submit

### DIFF
--- a/lib/subroutine/op.rb
+++ b/lib/subroutine/op.rb
@@ -18,8 +18,8 @@ module Subroutine
         self._failure_class = klass
       end
 
-      def submit!(*args)
-        raise ArgumentError, "Blocks cannot be provided to `submit!`" if block_given?
+      def submit!(*args, &block)
+        raise ArgumentError, "Blocks cannot be provided to `submit!`" if block
 
         op = new(*args)
         op.submit!
@@ -27,8 +27,8 @@ module Subroutine
         op
       end
 
-      def submit(*args)
-        raise ArgumentError, "Blocks cannot be provided to `submit`." if block_given?
+      def submit(*args, &block)
+        raise ArgumentError, "Blocks cannot be provided to `submit`." if block
 
         op = new(*args)
         op.submit


### PR DESCRIPTION
## Summary
- `Op.submit!`/`Op.submit` checked `block_given?` without an explicit `&block` param, which triggers Ruby 3.4's new "the block passed to ... may be ignored" warning whenever a block is passed.
- Capture the block explicitly via `&block` and check `if block` instead, which has identical behavior but silences the warning.

## Test plan
- [x] `bundle exec rake test` passes with no warnings (137 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)