### PR TITLE
Ignore major-version json Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,9 @@ updates:
     insecure-external-code-execution: deny
     allow:
       - dependency-type: "all"
+    ignore:
+      - dependency-name: "json"
+        update-types: ["version-update:semver-major"]
     commit-message:
       prefix: "[bundler] "
     groups:


### PR DESCRIPTION
Adds a static ignore rule to the bundler section of .github/dependabot.yml so Dependabot skips major-version bumps of the json gem, matching how it is already handled on other repos. json is currently resolved transitively (via activemodel/activesupport) with no direct gemspec declaration, so no Gemfile/gemspec change is needed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)